### PR TITLE
fix: correct template literal interpolation in usage stats tooltip

### DIFF
--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -708,7 +708,7 @@ class ProviderManager {
                     const tr = $el("tr", { style: { borderBottom: "1px solid var(--border-color)", background: isError ? "rgba(244,67,54,0.08)" : "transparent" } });
                     const date = new Date(row.timestamp * 1000).toLocaleString();
 
-                    tr.appendChild($el("td", { style: { padding: "8px", textAlign: "center" }, innerHTML: isError ? `<span style="color:#f44336" title=t("error")>✗</span>` : `<span style="color:#4CAF50" title=t("ok")>✓</span>` }));
+                    tr.appendChild($el("td", { style: { padding: "8px", textAlign: "center" }, innerHTML: isError ? `<span style="color:#f44336" title="${t("error")}">✗</span>` : `<span style="color:#4CAF50" title="${t("ok")}">✓</span>` }));
                     tr.appendChild($el("td", { style: { padding: "8px" }, textContent: date }));
                     tr.appendChild($el("td", { style: { padding: "8px", fontWeight: "bold" }, textContent: row.provider }));
                     tr.appendChild($el("td", { style: { padding: "8px" }, textContent: row.model }));


### PR DESCRIPTION
## Summary
- Fixed broken template literal interpolation in `provider_manager.js` line 711
- The `t("error")` and `t("ok")` i18n function calls were missing `${}` wrapper inside template literals, causing the raw expression text (e.g. `t("error")`) to appear as the HTML `title` attribute value instead of the translated string

## Test plan
- [ ] Open usage stats panel and hover over the status icon (checkmark or cross) to verify the tooltip shows the correctly translated text instead of raw source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)