### PR TITLE
fix: prevent enable toggle from silently saving unsaved edits

### DIFF
--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -755,7 +755,13 @@ class ProviderManager {
                 checked: draft.enabled,
                 onchange: (e) => {
                     draft.enabled = e.target.checked;
-                    this.saveProvider(draft); // auto save toggle
+                    // Save only the enabled state using the original provider data,
+                    // so that other unsaved draft edits (name, key, etc.) are not persisted.
+                    const original = this.providers.find(p => p.id === draft.id);
+                    if (original && !original._isNew) {
+                        original.enabled = e.target.checked;
+                        this.saveProvider({ ...original });
+                    }
                 }
             }),
             $el("span.llm-pm-slider")


### PR DESCRIPTION
## Summary
- The enable toggle's `onchange` was calling `saveProvider(draft)`, which saved the entire draft including uncommitted changes to name, API key, or URL
- Now it saves a copy of the original provider with only the `enabled` field updated

## Test plan
- [ ] Edit a provider's name (don't click Save)
- [ ] Toggle the Enable switch
- [ ] Verify only the enabled state changed; the name reverts to the original saved value
