### PR TITLE
feat: per-provider SSL verification toggle

### DIFF
--- a/config/default_providers.json
+++ b/config/default_providers.json
@@ -13,7 +13,8 @@
         "qwen-long"
       ],
       "enabled": true,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "deepseek",
@@ -26,7 +27,8 @@
         "deepseek-reasoner"
       ],
       "enabled": true,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "doubao",
@@ -36,7 +38,8 @@
       "apiHost": "https://ark.cn-beijing.volces.com/api/v3",
       "models": [],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "spark",
@@ -49,7 +52,8 @@
         "4.0Ultra"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "glm",
@@ -63,7 +67,8 @@
         "glm-4v-plus"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "moonshot",
@@ -77,7 +82,8 @@
         "moonshot-v1-128k"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "baichuan",
@@ -90,7 +96,8 @@
         "Baichuan3-Turbo"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "minimax",
@@ -103,7 +110,8 @@
         "abab6.5s-chat"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "stepfun",
@@ -116,7 +124,8 @@
         "step-2-16k"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "sensechat",
@@ -128,7 +137,8 @@
         "SenseChat-5"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "iflow",
@@ -138,7 +148,8 @@
       "apiHost": "https://apis.iflow.cn/v1",
       "models": [],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     },
     {
       "id": "modelscope",
@@ -150,7 +161,8 @@
         "Qwen/Qwen2.5-72B-Instruct"
       ],
       "enabled": false,
-      "isSystem": true
+      "isSystem": true,
+      "skipSSLVerify": true
     }
   ]
 }

--- a/nodes/api_client.py
+++ b/nodes/api_client.py
@@ -146,19 +146,26 @@ def log_error(err: APIError, provider_name: str, model: str,
 
 # ─── HTTP Client ─────────────────────────────────────────────────────────────
 
-# Shared SSL context (created once, reused across all calls)
-_ssl_context = None
+# Shared SSL contexts (created once, reused across all calls)
+_ssl_ctx_verify = None
+_ssl_ctx_noverify = None
 
-def _get_ssl_context() -> ssl.SSLContext:
-    """Get or create a lenient SSL context for Chinese API providers."""
-    global _ssl_context
-    if _ssl_context is None:
-        _ssl_context = ssl.create_default_context()
-        _ssl_context.check_hostname = False
-        _ssl_context.verify_mode = ssl.CERT_NONE
-        _ssl_context.set_ciphers("DEFAULT")
-        _ssl_context.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0)
-    return _ssl_context
+def _get_ssl_context(skip_verify: bool = False) -> ssl.SSLContext:
+    """Get or create an SSL context. Verification is ON by default."""
+    global _ssl_ctx_verify, _ssl_ctx_noverify
+    if skip_verify:
+        if _ssl_ctx_noverify is None:
+            _ssl_ctx_noverify = ssl.create_default_context()
+            _ssl_ctx_noverify.check_hostname = False
+            _ssl_ctx_noverify.verify_mode = ssl.CERT_NONE
+            _ssl_ctx_noverify.set_ciphers("DEFAULT")
+            _ssl_ctx_noverify.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0)
+        return _ssl_ctx_noverify
+    else:
+        if _ssl_ctx_verify is None:
+            _ssl_ctx_verify = ssl.create_default_context()
+            _ssl_ctx_verify.set_ciphers("DEFAULT")
+        return _ssl_ctx_verify
 
 
 def _normalize_url(base_url: str, path: str = "/chat/completions") -> str:
@@ -199,13 +206,14 @@ class LLMClient:
         api_key: str,
         max_retries: int = 3,
         timeout: int = 180,
+        skip_ssl_verify: bool = False,
     ):
         self.url = _normalize_url(base_url)
         self.base_url = self.url.replace("/chat/completions", "")
         self.api_key = api_key
         self.max_retries = max_retries
         self.timeout = timeout
-        self._ctx = _get_ssl_context()
+        self._ctx = _get_ssl_context(skip_ssl_verify)
         
     def _get_headers(self) -> Dict[str, str]:
         return {

--- a/nodes/llm_translator.py
+++ b/nodes/llm_translator.py
@@ -109,6 +109,7 @@ class LLMTranslator:
         start_time = time.time()
         
         # Build configuration (Use provided llm_config if connected, otherwise lookup from providers.json)
+        selected_provider = None
         if llm_config is None:
             providers_data = get_providers_data()
             selected_provider = next((p for p in providers_data if p["name"] == provider), None)
@@ -153,11 +154,13 @@ class LLMTranslator:
 
         # Call API via shared client
         try:
+            skip_ssl = selected_provider.get("skipSSLVerify", False) if selected_provider else False
             client = LLMClient(
                 base_url=config.get("base_url", ""),
                 api_key=config.get("api_key", ""),
                 max_retries=3,
                 timeout=60,
+                skip_ssl_verify=skip_ssl,
             )
             translated_text, _ = client.chat(payload)
 

--- a/nodes/openai_compatible.py
+++ b/nodes/openai_compatible.py
@@ -309,6 +309,7 @@ class OpenAICompatibleLoader:
         actual_model = "" if model in ("Custom Input", "Custom/手动输入", _FROM_INPUT, "") else model
         provider_id = "custom"
         provider_name = "Custom Endpoint"
+        p_config = None
 
         if provider == _FROM_INPUT:
             # Mode 1: All config comes from LLM_CONFIG input node
@@ -397,7 +398,8 @@ class OpenAICompatibleLoader:
 
         # ── Make API call ────────────────────────────────────────────
         try:
-            client = LLMClient(base_url, api_key)
+            skip_ssl = p_config.get("skipSSLVerify", False) if p_config else False
+            client = LLMClient(base_url, api_key, skip_ssl_verify=skip_ssl)
             response_content, data = client.chat(payload)
 
             # Extract reasoning content (DeepSeek/R1)

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -79,7 +79,9 @@ const I18N_DICT = {
         preview: "Preview: ",
         lang_switch: "中",
         menu_button: "LLM Manager",
-        menu_tooltip: "Manage LLM API Providers & Model Config"
+        menu_tooltip: "Manage LLM API Providers & Model Config",
+        skip_ssl: "Skip SSL Verification",
+        skip_ssl_hint: "Enable this if the provider has certificate issues (common with some Chinese API providers)."
     },
     zh: {
         manager_title: "LLM 管理器",
@@ -143,7 +145,9 @@ const I18N_DICT = {
         preview: "预览: ",
         lang_switch: "EN",
         menu_button: "LLM 管理器",
-        menu_tooltip: "管理 LLM API 供应商与模型配置"
+        menu_tooltip: "管理 LLM API 供应商与模型配置",
+        skip_ssl: "跳过 SSL 验证",
+        skip_ssl_hint: "如果供应商存在证书问题可开启此选项（部分国内供应商可能需要）。"
     }
 };
 
@@ -378,7 +382,7 @@ class ProviderManager {
         try {
             const res = await api.fetchApi("/llm_toolkit/providers/check", {
                 method: "POST",
-                body: JSON.stringify(checkBody)
+                body: JSON.stringify({ ...checkBody, skipSSLVerify: !!draft.skipSSLVerify })
             });
             const data = await res.json();
 
@@ -595,6 +599,7 @@ class ProviderManager {
             models: [],
             enabled: true,
             isSystem: false,
+            skipSSLVerify: false,
             _isNew: true
         };
         this.providers.push(newProvider);
@@ -968,6 +973,23 @@ class ProviderManager {
                     id: "pm-url-preview",
                     textContent: `${t("preview")}${draft.apiHost} /chat/completions`
                 })
+            ]),
+
+            $el("div.llm-pm-field", [
+                $el("div", { style: { display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: "0.8em", fontWeight: "600", color: "var(--glass-text-secondary)", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: "8px" } }, [
+                    $el("span", t("skip_ssl")),
+                    $el("label.llm-pm-switch", [
+                        $el("input", {
+                            type: "checkbox",
+                            checked: !!draft.skipSSLVerify,
+                            onchange: (e) => {
+                                draft.skipSSLVerify = e.target.checked;
+                            }
+                        }),
+                        $el("span.llm-pm-slider")
+                    ])
+                ]),
+                $el("div.llm-pm-field-hint", t("skip_ssl_hint"))
             ]),
 
             $el("div.llm-pm-field", [


### PR DESCRIPTION
## Summary

- Replace global SSL-disabled context with per-provider `skipSSLVerify` option — SSL verification is now **ON by default**
- Add `skipSSLVerify: true` to all Chinese API providers in `default_providers.json` (Qwen, DeepSeek, GLM, DouBao, Spark, Moonshot, Baichuan, MiniMax, StepFun, SenseChat, iFlow, ModelScope)
- Add "Skip SSL Verification" toggle switch in Provider Manager UI (bilingual EN/ZH) with hint text
- Pass `skipSSLVerify` flag through `check_provider` API, `OpenAICompatibleLoader`, and `LLMTranslator` nodes

## Test plan

- [ ] Verify existing Chinese providers (e.g. Qwen, DeepSeek) still connect successfully with `skipSSLVerify: true`
- [ ] Verify providers without the flag default to SSL verification enabled
- [ ] Toggle the switch in Provider Manager UI, save, and confirm the value persists
- [ ] Run "Check API" button and confirm `skipSSLVerify` is sent to backend
- [ ] Create a new custom provider and verify `skipSSLVerify` defaults to `false`
- [ ] Schema migration: existing `providers.json` without `skipSSLVerify` fields should get them from defaults on next load

🤖 Generated with [Claude Code](https://claude.com/claude-code)
