### PR TITLE
feat: add human-readable hints for API check failures

### DIFF
--- a/nodes/api_routes.py
+++ b/nodes/api_routes.py
@@ -261,9 +261,28 @@ async def check_provider(request: web.Request) -> web.Response:
         })
 
     except Exception as e:
+        error_msg = str(e)[:500]
+        hint = ""
+        error_lower = error_msg.lower()
+        if "401" in error_msg or "unauthorized" in error_lower or "authentication" in error_lower:
+            hint = "API Key may be invalid or expired. Please check and re-enter."
+        elif "403" in error_msg or "forbidden" in error_lower:
+            hint = "Access denied. Your API Key may lack required permissions."
+        elif "404" in error_msg or "not found" in error_lower:
+            hint = "Model or endpoint not found. Please verify the model name and Base URL."
+        elif "429" in error_msg or "rate" in error_lower or "quota" in error_lower:
+            hint = "Rate limited or quota exceeded. Check your usage on the provider's website."
+        elif "timeout" in error_lower or "timed out" in error_lower:
+            hint = "Connection timed out. Check your network or try again later."
+        elif "ssl" in error_lower or "certificate" in error_lower:
+            hint = "SSL certificate error. Try enabling 'Skip SSL Verification' for this provider."
+        elif "connection" in error_lower or "refused" in error_lower or "resolve" in error_lower:
+            hint = "Cannot connect to the server. Please check the Base URL and your network."
+
         return web.json_response({
             "status": "error",
-            "message": str(e)[:500]
+            "message": error_msg,
+            "hint": hint
         }, status=502)
 
 

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -36,6 +36,7 @@ const I18N_DICT = {
         connected: "Connected!",
         failed: "Failed",
         conn_failed: "Connection Failed",
+        error_detail: "Technical detail",
         network_err_title: "⚠️ Network Error",
         network_err_msg: "❌ Request failed. Network error or CORS issue.",
         search_placeholder: "Search providers/models...",
@@ -102,6 +103,7 @@ const I18N_DICT = {
         connected: "连通成功！",
         failed: "连接失败",
         conn_failed: "连接失败",
+        error_detail: "技术详情",
         network_err_title: "⚠️ 网络错误",
         network_err_msg: "❌ 请求失败。网络错误或存在跨域(CORS)限制。",
         search_placeholder: "搜索 供应商/模型...",
@@ -402,8 +404,11 @@ class ProviderManager {
                 btn.style.boxShadow = "0 0 12px rgba(248, 113, 113, 0.3)";
                 console.warn("[LLMs Toolkit] Connect Error: ", data.message);
 
-                // Still show the alert for the specific error message
-                setTimeout(() => this.showAlert(t("conn_failed"), "❌ " + data.message), 100);
+                // Show user-friendly hint (if available) with raw error as detail
+                const alertMsg = data.hint
+                    ? `${data.hint}\n\n${t("error_detail")}: ${data.message}`
+                    : `❌ ${data.message}`;
+                setTimeout(() => this.showAlert(t("conn_failed"), alertMsg), 100);
             }
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
## Summary
- Backend (`api_routes.py`): Classify API check errors (401, 403, 404, 429, timeout, SSL, connection) and return a `hint` field with user-friendly guidance alongside the raw error message.
- Frontend (`provider_manager.js`): Display the hint prominently in the alert when available, with the raw error shown as "Technical detail" below. Added `error_detail` i18n key in both EN and ZH.

## Test plan
- [ ] Trigger a 401 error (invalid API key) and verify the hint "API Key may be invalid or expired..." appears
- [ ] Trigger a connection error (bad URL) and verify the hint "Cannot connect to the server..." appears
- [ ] Trigger an error without a matching hint category and verify the raw message still shows with the cross icon
- [ ] Verify Chinese locale shows "技术详情" instead of "Technical detail"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
