### PR TITLE
fix: show "NEED KEY" status for providers without API key

### DIFF
--- a/config/default_providers.json
+++ b/config/default_providers.json
@@ -12,7 +12,7 @@
         "qwen-max",
         "qwen-long"
       ],
-      "enabled": true,
+      "enabled": false,
       "isSystem": true,
       "skipSSLVerify": true
     },
@@ -26,7 +26,7 @@
         "deepseek-chat",
         "deepseek-reasoner"
       ],
-      "enabled": true,
+      "enabled": false,
       "isSystem": true,
       "skipSSLVerify": true
     },

--- a/web/css/provider_manager.css
+++ b/web/css/provider_manager.css
@@ -216,6 +216,12 @@
     border-color: rgba(52, 211, 153, 0.25);
 }
 
+.llm-pm-tag.needkey {
+    background: rgba(251, 191, 36, 0.15);
+    color: #fbbf24;
+    border-color: rgba(251, 191, 36, 0.25);
+}
+
 /* -- Sidebar Footer -- */
 .llm-pm-sidebar-footer {
     padding: 12px 14px;

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -81,7 +81,8 @@ const I18N_DICT = {
         menu_button: "LLM Manager",
         menu_tooltip: "Manage LLM API Providers & Model Config",
         skip_ssl: "Skip SSL Verification",
-        skip_ssl_hint: "Enable this if the provider has certificate issues (common with some Chinese API providers)."
+        skip_ssl_hint: "Enable this if the provider has certificate issues (common with some Chinese API providers).",
+        need_key: "NEED KEY"
     },
     zh: {
         manager_title: "LLM 管理器",
@@ -147,7 +148,8 @@ const I18N_DICT = {
         menu_button: "LLM 管理器",
         menu_tooltip: "管理 LLM API 供应商与模型配置",
         skip_ssl: "跳过 SSL 验证",
-        skip_ssl_hint: "如果供应商存在证书问题可开启此选项（部分国内供应商可能需要）。"
+        skip_ssl_hint: "如果供应商存在证书问题可开启此选项（部分国内供应商可能需要）。",
+        need_key: "需配置"
     }
 };
 
@@ -632,7 +634,10 @@ class ProviderManager {
         filtered.forEach(p => {
             const isActive = this.selectedId === p.id;
 
-            const tags = [$el("span.llm-pm-tag" + (p.enabled ? ".on" : ""), p.enabled ? t("on") : t("off"))];
+            const hasKey = p.apiKey && p.apiKey !== "";
+            const tagClass = p.enabled ? (hasKey ? ".on" : ".needkey") : "";
+            const tagLabel = p.enabled ? (hasKey ? t("on") : t("need_key")) : t("off");
+            const tags = [$el("span.llm-pm-tag" + tagClass, tagLabel)];
 
             const item = $el("div.llm-pm-item" + (isActive ? ".active" : ""), {
                 onclick: () => {


### PR DESCRIPTION
## Summary
- Show "NEED KEY" (amber tag) instead of "ON" (green) for providers that are enabled but have no API key configured, preventing users from thinking unconfigured providers are ready to use
- Add i18n support for the new label (EN: "NEED KEY", ZH: "需配置")
- Change all default providers to `enabled: false` so new installs don't show misleading ON status

## Test plan
- [ ] Open LLM Manager sidebar — providers without keys show amber "NEED KEY" tag
- [ ] Add an API key to a provider and save — tag changes to green "ON"
- [ ] Disable a provider — tag shows default "OFF"
- [ ] Switch language to ZH — "NEED KEY" shows as "需配置"
- [ ] Fresh install uses `default_providers.json` with all providers disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)
