### PR TITLE
feat: add auto-fetch models button for provider configuration

### DIFF
--- a/nodes/api_routes.py
+++ b/nodes/api_routes.py
@@ -286,6 +286,54 @@ async def check_provider(request: web.Request) -> web.Response:
         }, status=502)
 
 
+async def fetch_models(request: web.Request) -> web.Response:
+    """POST /llm_toolkit/providers/models - Fetch available models from provider API."""
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+    provider_id = body.get("providerId", "").strip()
+    api_host = body.get("apiHost", "").strip()
+    skip_ssl = body.get("skipSSLVerify", False)
+
+    # Look up API key from stored config
+    api_key = ""
+    raw_key = body.get("apiKey", "").strip()
+    if raw_key and "•" not in raw_key:  # not masked
+        api_key = raw_key
+    elif provider_id:
+        data = _load_providers()
+        for p in data.get("providers", []):
+            if p.get("id") == provider_id:
+                api_key = p.get("apiKey", "")
+                break
+
+    if not api_key or not api_host:
+        return web.json_response({"error": "apiKey and apiHost are required"}, status=400)
+
+    try:
+        import api_client
+        import asyncio
+        client = api_client.LLMClient(base_url=api_host, api_key=api_key, skip_ssl_verify=skip_ssl)
+        result = await asyncio.to_thread(client.list_models)
+
+        # Extract model IDs from the response
+        models = []
+        if isinstance(result, dict) and "data" in result:
+            for m in result["data"]:
+                if isinstance(m, dict) and "id" in m:
+                    models.append(m["id"])
+
+        models.sort()
+        return web.json_response({"status": "ok", "models": models})
+    except Exception as e:
+        return web.json_response({
+            "status": "error",
+            "message": str(e)[:500]
+        }, status=502)
+
+
 async def get_usage_stats(request: web.Request) -> web.Response:
     """GET /llm_toolkit/usage — Return token usage history (last 500 entries)."""
     from collections import deque
@@ -333,6 +381,10 @@ try:
     @PromptServer.instance.routes.post("/llm_toolkit/providers/check")
     async def _route_check_provider(request):
         return await check_provider(request)
+
+    @PromptServer.instance.routes.post("/llm_toolkit/providers/models")
+    async def _route_fetch_models(request):
+        return await fetch_models(request)
 
     print("[LLMs_Toolkit] ✓ All API routes registered (including /llm_toolkit/usage)")
 except Exception as e:

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -88,6 +88,7 @@ const I18N_DICT = {
         fetching_models: "Fetching...",
         fetch_models_err: "Failed to fetch models",
         models_found: " models found",
+        new_models_added: " new",
         no_models_found: "No models returned. The provider may not support the /models endpoint."
     },
     zh: {
@@ -161,6 +162,7 @@ const I18N_DICT = {
         fetching_models: "获取中...",
         fetch_models_err: "获取模型失败",
         models_found: " 个模型已获取",
+        new_models_added: " 个新增",
         no_models_found: "未返回模型列表，该供应商可能不支持 /models 接口。"
     }
 };
@@ -958,109 +960,7 @@ class ProviderManager {
                                 }
                             });
                             renderModels();
-                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
-                        } else if (data.status === "ok") {
-                            this.showAlert(t("fetch_models"), t("no_models_found"));
-                        } else {
-                            this.showAlert(t("fetch_models_err"), data.message || "Unknown error");
-                        }
-                    } catch (e) {
-                        this.showAlert(t("fetch_models_err"), e.message);
-                    }
-
-                    fetchModelsBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models");
-                    fetchModelsBtn.style.pointerEvents = "";
-                }
-            });
-            modelsContainer.appendChild(fetchModelsBtn);
-
-            // Fetch Models button
-            const fetchModelsBtn = $el("span", {
-                className: "llm-pm-model-add",
-                innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models"),
-                onclick: async () => {
-                    fetchModelsBtn.innerHTML = t("fetching_models");
-                    fetchModelsBtn.style.pointerEvents = "none";
-
-                    const isNew = draft._isNew || (draft.id && draft.id.startsWith("temp-"));
-                    const fetchBody = { apiHost: draft.apiHost, skipSSLVerify: !!draft.skipSSLVerify };
-                    if (isNew) {
-                        fetchBody.apiKey = draft.apiKey;
-                    } else {
-                        fetchBody.providerId = draft.id;
-                        if (draft.apiKey && !draft.apiKey.includes("\u2022\u2022\u2022\u2022")) {
-                            fetchBody.apiKey = draft.apiKey;
-                        }
-                    }
-
-                    try {
-                        const res = await api.fetchApi("/llm_toolkit/providers/models", {
-                            method: "POST",
-                            body: JSON.stringify(fetchBody)
-                        });
-                        const data = await res.json();
-                        if (data.status === "ok" && data.models && data.models.length > 0) {
-                            const existingSet = new Set(draft.models);
-                            let addedCount = 0;
-                            data.models.forEach(m => {
-                                if (!existingSet.has(m)) {
-                                    draft.models.push(m);
-                                    addedCount++;
-                                }
-                            });
-                            renderModels();
-                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
-                        } else if (data.status === "ok") {
-                            this.showAlert(t("fetch_models"), t("no_models_found"));
-                        } else {
-                            this.showAlert(t("fetch_models_err"), data.message || "Unknown error");
-                        }
-                    } catch (e) {
-                        this.showAlert(t("fetch_models_err"), e.message);
-                    }
-
-                    fetchModelsBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models");
-                    fetchModelsBtn.style.pointerEvents = "";
-                }
-            });
-            modelsContainer.appendChild(fetchModelsBtn);
-
-            // Fetch Models button
-            const fetchModelsBtn = $el("span", {
-                className: "llm-pm-model-add",
-                innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models"),
-                onclick: async () => {
-                    fetchModelsBtn.innerHTML = t("fetching_models");
-                    fetchModelsBtn.style.pointerEvents = "none";
-
-                    const isNew = draft._isNew || (draft.id && draft.id.startsWith("temp-"));
-                    const fetchBody = { apiHost: draft.apiHost, skipSSLVerify: !!draft.skipSSLVerify };
-                    if (isNew) {
-                        fetchBody.apiKey = draft.apiKey;
-                    } else {
-                        fetchBody.providerId = draft.id;
-                        if (draft.apiKey && !draft.apiKey.includes("\u2022\u2022\u2022\u2022")) {
-                            fetchBody.apiKey = draft.apiKey;
-                        }
-                    }
-
-                    try {
-                        const res = await api.fetchApi("/llm_toolkit/providers/models", {
-                            method: "POST",
-                            body: JSON.stringify(fetchBody)
-                        });
-                        const data = await res.json();
-                        if (data.status === "ok" && data.models && data.models.length > 0) {
-                            const existingSet = new Set(draft.models);
-                            let addedCount = 0;
-                            data.models.forEach(m => {
-                                if (!existingSet.has(m)) {
-                                    draft.models.push(m);
-                                    addedCount++;
-                                }
-                            });
-                            renderModels();
-                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
+                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount}${t("new_models_added")})` : ""));
                         } else if (data.status === "ok") {
                             this.showAlert(t("fetch_models"), t("no_models_found"));
                         } else {

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -83,7 +83,12 @@ const I18N_DICT = {
         menu_tooltip: "Manage LLM API Providers & Model Config",
         skip_ssl: "Skip SSL Verification",
         skip_ssl_hint: "Enable this if the provider has certificate issues (common with some Chinese API providers).",
-        need_key: "NEED KEY"
+        need_key: "NEED KEY",
+        fetch_models: "Fetch Models",
+        fetching_models: "Fetching...",
+        fetch_models_err: "Failed to fetch models",
+        models_found: " models found",
+        no_models_found: "No models returned. The provider may not support the /models endpoint."
     },
     zh: {
         manager_title: "LLM 管理器",
@@ -151,7 +156,12 @@ const I18N_DICT = {
         menu_tooltip: "管理 LLM API 供应商与模型配置",
         skip_ssl: "跳过 SSL 验证",
         skip_ssl_hint: "如果供应商存在证书问题可开启此选项（部分国内供应商可能需要）。",
-        need_key: "需配置"
+        need_key: "需配置",
+        fetch_models: "获取模型列表",
+        fetching_models: "获取中...",
+        fetch_models_err: "获取模型失败",
+        models_found: " 个模型已获取",
+        no_models_found: "未返回模型列表，该供应商可能不支持 /models 接口。"
     }
 };
 
@@ -912,6 +922,159 @@ class ProviderManager {
                     })
                 ]));
             });
+
+            // Fetch Models button
+            const fetchModelsBtn = $el("span", {
+                className: "llm-pm-model-add",
+                innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models"),
+                onclick: async () => {
+                    fetchModelsBtn.innerHTML = t("fetching_models");
+                    fetchModelsBtn.style.pointerEvents = "none";
+
+                    const isNew = draft._isNew || (draft.id && draft.id.startsWith("temp-"));
+                    const fetchBody = { apiHost: draft.apiHost, skipSSLVerify: !!draft.skipSSLVerify };
+                    if (isNew) {
+                        fetchBody.apiKey = draft.apiKey;
+                    } else {
+                        fetchBody.providerId = draft.id;
+                        if (draft.apiKey && !draft.apiKey.includes("\u2022\u2022\u2022\u2022")) {
+                            fetchBody.apiKey = draft.apiKey;
+                        }
+                    }
+
+                    try {
+                        const res = await api.fetchApi("/llm_toolkit/providers/models", {
+                            method: "POST",
+                            body: JSON.stringify(fetchBody)
+                        });
+                        const data = await res.json();
+                        if (data.status === "ok" && data.models && data.models.length > 0) {
+                            const existingSet = new Set(draft.models);
+                            let addedCount = 0;
+                            data.models.forEach(m => {
+                                if (!existingSet.has(m)) {
+                                    draft.models.push(m);
+                                    addedCount++;
+                                }
+                            });
+                            renderModels();
+                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
+                        } else if (data.status === "ok") {
+                            this.showAlert(t("fetch_models"), t("no_models_found"));
+                        } else {
+                            this.showAlert(t("fetch_models_err"), data.message || "Unknown error");
+                        }
+                    } catch (e) {
+                        this.showAlert(t("fetch_models_err"), e.message);
+                    }
+
+                    fetchModelsBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models");
+                    fetchModelsBtn.style.pointerEvents = "";
+                }
+            });
+            modelsContainer.appendChild(fetchModelsBtn);
+
+            // Fetch Models button
+            const fetchModelsBtn = $el("span", {
+                className: "llm-pm-model-add",
+                innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models"),
+                onclick: async () => {
+                    fetchModelsBtn.innerHTML = t("fetching_models");
+                    fetchModelsBtn.style.pointerEvents = "none";
+
+                    const isNew = draft._isNew || (draft.id && draft.id.startsWith("temp-"));
+                    const fetchBody = { apiHost: draft.apiHost, skipSSLVerify: !!draft.skipSSLVerify };
+                    if (isNew) {
+                        fetchBody.apiKey = draft.apiKey;
+                    } else {
+                        fetchBody.providerId = draft.id;
+                        if (draft.apiKey && !draft.apiKey.includes("\u2022\u2022\u2022\u2022")) {
+                            fetchBody.apiKey = draft.apiKey;
+                        }
+                    }
+
+                    try {
+                        const res = await api.fetchApi("/llm_toolkit/providers/models", {
+                            method: "POST",
+                            body: JSON.stringify(fetchBody)
+                        });
+                        const data = await res.json();
+                        if (data.status === "ok" && data.models && data.models.length > 0) {
+                            const existingSet = new Set(draft.models);
+                            let addedCount = 0;
+                            data.models.forEach(m => {
+                                if (!existingSet.has(m)) {
+                                    draft.models.push(m);
+                                    addedCount++;
+                                }
+                            });
+                            renderModels();
+                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
+                        } else if (data.status === "ok") {
+                            this.showAlert(t("fetch_models"), t("no_models_found"));
+                        } else {
+                            this.showAlert(t("fetch_models_err"), data.message || "Unknown error");
+                        }
+                    } catch (e) {
+                        this.showAlert(t("fetch_models_err"), e.message);
+                    }
+
+                    fetchModelsBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models");
+                    fetchModelsBtn.style.pointerEvents = "";
+                }
+            });
+            modelsContainer.appendChild(fetchModelsBtn);
+
+            // Fetch Models button
+            const fetchModelsBtn = $el("span", {
+                className: "llm-pm-model-add",
+                innerHTML: `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models"),
+                onclick: async () => {
+                    fetchModelsBtn.innerHTML = t("fetching_models");
+                    fetchModelsBtn.style.pointerEvents = "none";
+
+                    const isNew = draft._isNew || (draft.id && draft.id.startsWith("temp-"));
+                    const fetchBody = { apiHost: draft.apiHost, skipSSLVerify: !!draft.skipSSLVerify };
+                    if (isNew) {
+                        fetchBody.apiKey = draft.apiKey;
+                    } else {
+                        fetchBody.providerId = draft.id;
+                        if (draft.apiKey && !draft.apiKey.includes("\u2022\u2022\u2022\u2022")) {
+                            fetchBody.apiKey = draft.apiKey;
+                        }
+                    }
+
+                    try {
+                        const res = await api.fetchApi("/llm_toolkit/providers/models", {
+                            method: "POST",
+                            body: JSON.stringify(fetchBody)
+                        });
+                        const data = await res.json();
+                        if (data.status === "ok" && data.models && data.models.length > 0) {
+                            const existingSet = new Set(draft.models);
+                            let addedCount = 0;
+                            data.models.forEach(m => {
+                                if (!existingSet.has(m)) {
+                                    draft.models.push(m);
+                                    addedCount++;
+                                }
+                            });
+                            renderModels();
+                            this.showAlert("\u2713", `${data.models.length}${t("models_found")}` + (addedCount > 0 ? ` (+${addedCount} new)` : ""));
+                        } else if (data.status === "ok") {
+                            this.showAlert(t("fetch_models"), t("no_models_found"));
+                        } else {
+                            this.showAlert(t("fetch_models_err"), data.message || "Unknown error");
+                        }
+                    } catch (e) {
+                        this.showAlert(t("fetch_models_err"), e.message);
+                    }
+
+                    fetchModelsBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="margin-right:4px"><path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/></svg>` + t("fetch_models");
+                    fetchModelsBtn.style.pointerEvents = "";
+                }
+            });
+            modelsContainer.appendChild(fetchModelsBtn);
 
             // Add button
             modelsContainer.appendChild($el("span.llm-pm-model-add", {


### PR DESCRIPTION
## Summary
- Add a new "Fetch Models" button in the Provider Manager UI, next to the existing "+ Add Model" button
- New backend endpoint `POST /llm_toolkit/providers/models` queries the provider's `/models` API to discover available models
- Fetched models are merged with existing ones (no duplicates), with clear feedback on how many were found and added
- Full i18n support (English and Chinese) for all new UI strings

## Test plan
- [ ] Open Provider Manager, select a provider with a valid API key and base URL
- [ ] Click "Fetch Models" and verify models are populated automatically
- [ ] Verify duplicate models are not added if button is clicked again
- [ ] Test with a provider that does not support `/models` endpoint - should show appropriate error
- [ ] Test with a new (unsaved) provider - should send API key directly
- [ ] Verify Chinese translations by switching language
