### PR TITLE
fix: prevent enable toggle from discarding unsaved edits

### DIFF
--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -882,14 +882,15 @@ class ProviderManager {
             $el("input", {
                 type: "checkbox",
                 checked: draft.enabled,
-                onchange: (e) => {
+                onchange: async (e) => {
                     draft.enabled = e.target.checked;
                     // Save only the enabled state using the original provider data,
                     // so that other unsaved draft edits (name, key, etc.) are not persisted.
                     const original = this.providers.find(p => p.id === draft.id);
                     if (original && !original._isNew) {
                         original.enabled = e.target.checked;
-                        this.saveProvider({ ...original });
+                        await this.saveProvider({ ...original }, { skipRender: true });
+                        this.renderSidebar();
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- The Enable toggle's `onchange` handler called `saveProvider()` without `{ skipRender: true }`, which triggered a full `render()` cycle that rebuilt the content area from server data, silently discarding any unsaved edits in name/URL/key/model fields.
- Pass `{ skipRender: true }` to `saveProvider()` and call `renderSidebar()` after the save to update only the ON/OFF tag and status dot without touching the content panel.

## Test plan
- [ ] Open a provider, edit the name or API key (do NOT save yet)
- [ ] Toggle the Enable switch on/off
- [ ] Verify the sidebar tag updates to reflect the new enabled state
- [ ] Verify the unsaved edits in the content panel are preserved
