### PR TITLE
fix: show welcome guide on first visit by deferring auto-select

### DIFF
--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -337,8 +337,9 @@ class ProviderManager {
             const data = await res.json();
             this.providers = data.providers || [];
 
-            // Auto-select first if none selected
-            if (!this.selectedId && this.providers.length > 0) {
+            // Auto-select first if none selected (skip on first visit to show welcome)
+            const hasVisited = localStorage.getItem("llm_pm_has_visited");
+            if (!this.selectedId && this.providers.length > 0 && hasVisited) {
                 this.selectedId = this.providers[0].id;
             }
             // Ensure selectedId is still valid
@@ -713,6 +714,9 @@ class ProviderManager {
                     if (this.selectedId === p.id) return;
                     this.checkUnsaved(() => {
                         this.selectedId = p.id;
+                        if (!localStorage.getItem("llm_pm_has_visited")) {
+                            localStorage.setItem("llm_pm_has_visited", "1");
+                        }
                         this.render();
                     });
                 }

--- a/web/js/provider_manager.js
+++ b/web/js/provider_manager.js
@@ -882,14 +882,15 @@ class ProviderManager {
             $el("input", {
                 type: "checkbox",
                 checked: draft.enabled,
-                onchange: (e) => {
+                onchange: async (e) => {
                     draft.enabled = e.target.checked;
                     // Save only the enabled state using the original provider data,
                     // so that other unsaved draft edits (name, key, etc.) are not persisted.
                     const original = this.providers.find(p => p.id === draft.id);
                     if (original && !original._isNew) {
                         original.enabled = e.target.checked;
-                        this.saveProvider({ ...original });
+                        await this.saveProvider({ ...original }, { skipRender: true });
+                        this.renderSidebar();
                     }
                 }
             }),


### PR DESCRIPTION
## Summary
- First-time users could never see the welcome card because `loadProviders()` auto-selected the first provider unconditionally
- Use `localStorage("llm_pm_has_visited")` to detect first visit and skip auto-select, allowing the welcome card to display naturally
- Once the user clicks any provider, the flag is set so subsequent visits auto-select as before

## Test plan
- [ ] Clear localStorage (`localStorage.removeItem("llm_pm_has_visited")`) and open Provider Manager — welcome card should be visible
- [ ] Click a provider — it should load normally and set the visited flag
- [ ] Reopen Provider Manager — first provider should be auto-selected (no welcome card)
