### PR TITLE
fix: reorder optional inputs to prevent widget value drift (#25)

### DIFF
--- a/nodes/openai_compatible.py
+++ b/nodes/openai_compatible.py
@@ -137,12 +137,12 @@ class OpenAICompatibleLoader:
                 "prompt": ("STRING", {"multiline": True, "default": "hello"}),
             },
             "optional": {
-                "llm_config": ("LLM_CONFIG",),  # Keep for backward compatibility
-                "prep_img": ("STRING", {"default": "", "forceInput": True}),
                 "temperature": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 2.0}),
                 "max_tokens": ("INT", {"default": 2048, "min": 1, "max": 4096}),
                 "enable_memory": ("BOOLEAN", {"default": False, "label": "Enable Memory"}),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff})
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "llm_config": ("LLM_CONFIG",),
+                "prep_img": ("STRING", {"default": "", "forceInput": True}),
             },
             "hidden": {"unique_id": "UNIQUE_ID"}
         }


### PR DESCRIPTION
## Summary
- Move non-widget inputs (`llm_config`, `prep_img`) after widget-creating inputs in the optional dict
- Prevents `widgets_values` positional index misalignment caused by ComfyUI's array-based serialization

## Root Cause
ComfyUI frontend serializes widget values as a positional array (`widgets_values[t++]`), not a named dict. Inputs with `forceInput: True` or custom types don't generate widgets, but their position in the optional dict can shift widget indices across different ComfyUI versions, causing values like `temperature=0.3` to end up in `max_tokens`.

## Fix
Reorder optional dict: widget inputs first, non-widget inputs last.

Closes #25